### PR TITLE
Replace dev branch with rc

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -46,7 +46,7 @@ body:
     attributes:
       label: Version
       description: On what version is the issue present
-      placeholder: e.g. dev/7.0-dev3
+      placeholder: e.g. 16.2.6-rc.1
     validations:
       required: true
   - type: input
@@ -61,6 +61,5 @@ body:
     attributes:
       label: "Confirmation of issue's presence"
       options:
-      - label: "*By submitting this ticket, I affirm that I have verified the presence of this issue on the latest developer version available at the time of writing this ticket.*"
+      - label: "*By submitting this ticket, I affirm that I have verified the presence of this issue on the latest RC (Release Candidate) version available at the time of writing this ticket.*"
         required: true
-

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,15 +1,15 @@
---- 
+---
 blank_issues_enabled: false
-contact_links: 
-  - 
-    about: "Please ask and answer usage questions on Stack Overflow."
-    name: "Question"
-    url: "https://stackoverflow.com/questions/tagged/altv"
-  - 
-    about: "Alternatively, you can use the alt:V Official Discord."
-    name: "Support channel"
-    url: "https://discord.altv.mp/"
-  - 
+contact_links:
+  -
     about: "Please check the Troubleshooting before filing new issues."
     name: "alt:V Troubleshooting"
     url: "https://docs.altv.mp/articles/troubleshooting/client.html"
+  -
+    about: "Alternatively, you can use the alt:V Official Discord."
+    name: "Support channel"
+    url: "https://discord.altv.mp/"
+  -
+    about: "Please ask and answer usage questions on Stack Overflow."
+    name: "Question"
+    url: "https://stackoverflow.com/questions/tagged/altv"


### PR DESCRIPTION
Since update `16.2.6-rc.1`, the public `dev` branch is no longer available.